### PR TITLE
Fix UnboundLocalError in save_image_to_file 

### DIFF
--- a/backend/trip/utils/utils.py
+++ b/backend/trip/utils/utils.py
@@ -177,6 +177,7 @@ def patch_image(fp: str, size: int = 400) -> bool:
 
 
 def save_image_to_file(content: bytes, size: int = 600) -> str:
+    filepath = None
     try:
         with Image.open(BytesIO(content)) as im:
             if im.mode not in ("RGB", "RGBA"):
@@ -218,7 +219,7 @@ def save_image_to_file(content: bytes, size: int = 600) -> str:
             return filename
 
     except Exception:
-        if filepath.exists():
+        if filepath and filepath.exists():
             filepath.unlink()
     return ""
 


### PR DESCRIPTION
Fixes #135

- Initialize filepath to None before try block
- Add null check before accessing filepath.exists() in except block
- Prevents 500 error when Google Maps returns invalid image data
- Application now fails gracefully, returning empty string instead of crashing