### PR TITLE
💄 allow showing text and place prop at the same time

### DIFF
--- a/src/src/app/components/trip/trip.component.html
+++ b/src/src/app/components/trip/trip.component.html
@@ -303,6 +303,11 @@
                   <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2 min-w-0">
                       @if (item.place && visibleProps.has('place')) {
+                        @if (visibleProps.has('text') && item.text != item.place.name) {
+                        <span class="pointer-events-none text-sm font-medium text-primary-900 dark:text-white truncate">
+                          {{ item.text }}
+                        </span>
+                        }
                       <div class="flex color-bg-opacity items-center gap-2 px-2.5 py-1 rounded-lg min-w-0 max-w-full"
                         [style.--color-bg-opacity]="item.place.category.color">
                         <img [src]="item.place.image || item.place.category.image"

--- a/src/src/app/components/trip/trip.component.ts
+++ b/src/src/app/components/trip/trip.component.ts
@@ -453,7 +453,7 @@ export class TripComponent implements AfterViewInit, OnDestroy {
   menuSelectedDayActionsItems: MenuItem[] = [];
   selectedTripDayForMenu?: TripDay;
   statuses: TripStatus[];
-  availableItemProps = ['place', 'comment', 'latlng', 'price', 'status', 'distance'];
+  availableItemProps = ['text', 'place', 'comment', 'latlng', 'price', 'status', 'distance'];
 
   map?: L.Map;
   markerClusterGroup?: L.MarkerClusterGroup;


### PR DESCRIPTION
Took me way longer than I'd like to admit and had to run it in a VM to be able to build it as no lightingcss on illumos.

I asked for this a while ago but not sure why it wasn't doable anymore but it kept bugging me so I spend a few hours over the last week trying to get it to at least work and see why it would be a bad idea. But I can't find a reason why this isn't OK.

### Current version + default view after this PR:
<img width="466" height="579" alt="default_filter" src="https://github.com/user-attachments/assets/05a15e40-7234-48a5-81ac-02e59dfc793a" />

### After unchecking 'place' from the filter 
> the view I use now basically as I want text over place, ideally both (this PR)
> Aside from `text` being listed in the drop-down nothing changed so far.

<img width="335" height="333" alt="default-place" src="https://github.com/user-attachments/assets/d977edfa-80d0-45fe-b0b9-ea8aecc96354" />
<img width="490" height="488" alt="default-place_view" src="https://github.com/user-attachments/assets/7382e56b-d619-49cb-99e7-cceaa5c29748" />

### Both place and text unchecked
> We need to show something so text is still show, I didn't find a way to disable the `text` checkbox in the dropdown if `place` is unchecked)
> I think this is OK, currently we don't show `text` in the dropdown but when place is unchecked, text is show instead currently too.

<img width="476" height="579" alt="default-place-text_view" src="https://github.com/user-attachments/assets/0c4b2f2f-e80d-41ac-bdef-ab2e3ee49417" />

### Both place and text checked
> Basically the view I wanted

<img width="349" height="353" alt="default+text" src="https://github.com/user-attachments/assets/fec501ba-117e-4f2e-93d7-d671c231e993" />
<img width="467" height="632" alt="default+text_view" src="https://github.com/user-attachments/assets/9af127a7-7d96-4419-8ca8-e8e148fb37ee" />

> If text and place.name are the same, we show it like this

<img width="465" height="448" alt="text_place_same_view" src="https://github.com/user-attachments/assets/7dcaedca-d892-4b9f-b607-45f2b69e2632" />
