### PR TITLE
feat: MCP server for AI-powered trip management

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 3001
+CMD ["python", "server.py"]

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,39 @@
+# TRIP MCP Server
+
+MCP (Model Context Protocol) server for TRIP — lets AI assistants (Claude, OpenClaw, etc.) manage trips via tools.
+
+## Tools (22)
+
+Trips: create, list, get, update, delete, link_places
+Days: add, update, delete
+Items: add, update, delete
+Places: create, list, update, delete
+Categories: list, create
+Packing: add_packing_item
+Checklist: add_checklist_item
+Sharing: share_trip, invite_member
+
+## Setup
+
+```bash
+docker compose up -d
+```
+
+Environment variables:
+- `TRIP_API_URL` — TRIP backend URL (default: http://localhost:8080)
+- `TRIP_USERNAME` — Login username
+- `TRIP_PASSWORD` — Login password
+
+## Connect
+
+Claude Code (`~/.claude/settings.json`):
+```json
+{
+  "mcpServers": {
+    "trip": {
+      "type": "sse",
+      "url": "http://localhost:3001/sse"
+    }
+  }
+}
+```

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -20,6 +20,7 @@ docker compose up -d
 ```
 
 Environment variables:
+
 - `TRIP_API_URL` — TRIP backend URL (default: http://localhost:8080)
 - `TRIP_USERNAME` — Login username
 - `TRIP_PASSWORD` — Login password
@@ -27,12 +28,13 @@ Environment variables:
 ## Connect
 
 Claude Code (`~/.claude/settings.json`):
+
 ```json
 {
   "mcpServers": {
     "trip": {
-      "type": "sse",
-      "url": "http://localhost:3001/sse"
+      "type": "http",
+      "url": "http://localhost:3001/mcp"
     }
   }
 }

--- a/mcp-server/auth.py
+++ b/mcp-server/auth.py
@@ -1,0 +1,61 @@
+"""JWT auth handler with token caching for TRIP API."""
+import os
+import time
+import httpx
+
+_token = None
+_token_expires = 0.0
+
+
+def get_api_url():
+    return os.environ.get("TRIP_API_URL", "http://localhost:8080")
+
+
+async def get_token():
+    global _token, _token_expires
+    if _token and time.time() < _token_expires:
+        return _token
+    username = os.environ.get("TRIP_USERNAME", "")
+    password = os.environ.get("TRIP_PASSWORD", "")
+    if not username or not password:
+        raise RuntimeError("TRIP_USERNAME and TRIP_PASSWORD env vars required")
+    async with httpx.AsyncClient(base_url=get_api_url()) as client:
+        r = await client.post("/api/auth/login", json={"username": username, "password": password})
+        r.raise_for_status()
+        data = r.json()
+        _token = data["access_token"]
+        _token_expires = time.time() + 25 * 60
+        return _token
+
+
+async def api_get(path):
+    token = await get_token()
+    async with httpx.AsyncClient(base_url=get_api_url(), timeout=30) as client:
+        r = await client.get(path, headers={"Authorization": f"Bearer {token}"})
+        if r.status_code == 404:
+            return {}
+        r.raise_for_status()
+        return r.json()
+
+
+async def api_post(path, data):
+    token = await get_token()
+    async with httpx.AsyncClient(base_url=get_api_url(), timeout=30) as client:
+        r = await client.post(path, json=data, headers={"Authorization": f"Bearer {token}"})
+        r.raise_for_status()
+        return r.json()
+
+
+async def api_put(path, data):
+    token = await get_token()
+    async with httpx.AsyncClient(base_url=get_api_url(), timeout=30) as client:
+        r = await client.put(path, json=data, headers={"Authorization": f"Bearer {token}"})
+        r.raise_for_status()
+        return r.json()
+
+
+async def api_delete(path):
+    token = await get_token()
+    async with httpx.AsyncClient(base_url=get_api_url(), timeout=30) as client:
+        await client.delete(path, headers={"Authorization": f"Bearer {token}"})
+        return {"deleted": True}

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,0 +1,2 @@
+fastmcp>=2.0
+httpx>=0.28

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,2 +1,2 @@
-fastmcp>=2.0
-httpx>=0.28
+fastmcp~=3.0
+httpx~=0.28

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -1,0 +1,153 @@
+"""TRIP MCP Server — manage trips, places, and itineraries via AI tools."""
+from fastmcp import FastMCP
+from auth import api_get, api_post, api_put, api_delete
+
+mcp = FastMCP("TRIP")
+
+# ── Trips ──
+
+@mcp.tool()
+async def create_trip(name: str, currency: str = "EUR") -> dict:
+    """Create a new trip."""
+    return await api_post("/api/trips", {"name": name, "currency": currency})
+
+@mcp.tool()
+async def list_trips() -> list:
+    """List all trips."""
+    return await api_get("/api/trips")
+
+@mcp.tool()
+async def get_trip(trip_id: int) -> dict:
+    """Get full trip with days, items, and places."""
+    return await api_get(f"/api/trips/{trip_id}")
+
+@mcp.tool()
+async def update_trip(trip_id: int, name: str = "", currency: str = "", notes: str = "") -> dict:
+    """Update trip name, currency, or notes."""
+    data = {k: v for k, v in {"name": name, "currency": currency, "notes": notes}.items() if v}
+    return await api_put(f"/api/trips/{trip_id}", data)
+
+@mcp.tool()
+async def delete_trip(trip_id: int) -> dict:
+    """Delete a trip."""
+    return await api_delete(f"/api/trips/{trip_id}")
+
+@mcp.tool()
+async def link_places(trip_id: int, place_ids: list[int]) -> dict:
+    """Link places to a trip. Must be called before adding items with place references."""
+    return await api_put(f"/api/trips/{trip_id}", {"place_ids": place_ids})
+
+# ── Days ──
+
+@mcp.tool()
+async def add_day(trip_id: int, label: str, date: str = "") -> dict:
+    """Add a day. Date: YYYY-MM-DD."""
+    data = {"label": label}
+    if date: data["dt"] = date
+    return await api_post(f"/api/trips/{trip_id}/days", data)
+
+@mcp.tool()
+async def update_day(trip_id: int, day_id: int, label: str = "", date: str = "") -> dict:
+    """Update a day."""
+    data = {}
+    if label: data["label"] = label
+    if date: data["dt"] = date
+    return await api_put(f"/api/trips/{trip_id}/days/{day_id}", data)
+
+@mcp.tool()
+async def delete_day(trip_id: int, day_id: int) -> dict:
+    """Delete a day."""
+    return await api_delete(f"/api/trips/{trip_id}/days/{day_id}")
+
+# ── Items ──
+
+@mcp.tool()
+async def add_item(trip_id: int, day_id: int, text: str, time: str = "09:00",
+                   price: float = 0, place_id: int = 0) -> dict:
+    """Add an item to a day. Field is 'place' not 'place_id'. Place must be linked to trip first."""
+    data = {"text": text, "time": time, "price": price}
+    if place_id: data["place"] = place_id
+    return await api_post(f"/api/trips/{trip_id}/days/{day_id}/items", data)
+
+@mcp.tool()
+async def update_item(trip_id: int, day_id: int, item_id: int, text: str = "", time: str = "") -> dict:
+    """Update an item."""
+    data = {}
+    if text: data["text"] = text
+    if time: data["time"] = time
+    return await api_put(f"/api/trips/{trip_id}/days/{day_id}/items/{item_id}", data)
+
+@mcp.tool()
+async def delete_item(trip_id: int, day_id: int, item_id: int) -> dict:
+    """Delete an item."""
+    return await api_delete(f"/api/trips/{trip_id}/days/{day_id}/items/{item_id}")
+
+# ── Places ──
+
+@mcp.tool()
+async def create_place(name: str, lat: float, lng: float, category_id: int = 1,
+                       description: str = "", price: float = 0, duration: int = 60,
+                       image_url: str = "") -> dict:
+    """Create a place. Pass image_url for a photo (server downloads automatically)."""
+    data = {"name": name, "lat": lat, "lng": lng, "place": name,
+            "description": description, "price": price, "duration": duration,
+            "category_id": category_id}
+    if image_url: data["image"] = image_url
+    return await api_post("/api/places", data)
+
+@mcp.tool()
+async def list_places() -> list:
+    """List all places."""
+    return await api_get("/api/places")
+
+@mcp.tool()
+async def update_place(place_id: int, name: str = "", description: str = "") -> dict:
+    """Update a place."""
+    data = {}
+    if name: data["name"] = name
+    if description: data["description"] = description
+    return await api_put(f"/api/places/{place_id}", data)
+
+@mcp.tool()
+async def delete_place(place_id: int) -> dict:
+    """Delete a place."""
+    return await api_delete(f"/api/places/{place_id}")
+
+# ── Categories ──
+
+@mcp.tool()
+async def list_categories() -> list:
+    """List place categories."""
+    return await api_get("/api/categories")
+
+@mcp.tool()
+async def create_category(name: str, color: str = "#3B82F6") -> dict:
+    """Create a category."""
+    return await api_post("/api/categories", {"name": name, "color": color})
+
+# ── Packing & Checklist ──
+
+@mcp.tool()
+async def add_packing_item(trip_id: int, text: str, category: str = "other", quantity: int = 1) -> dict:
+    """Add packing item. Categories: clothes, toiletries, tech, documents, other."""
+    return await api_post(f"/api/trips/{trip_id}/packing", {"text": text, "category": category, "qt": quantity})
+
+@mcp.tool()
+async def add_checklist_item(trip_id: int, text: str) -> dict:
+    """Add pre-trip checklist item."""
+    return await api_post(f"/api/trips/{trip_id}/checklist", {"text": text})
+
+# ── Sharing ──
+
+@mcp.tool()
+async def share_trip(trip_id: int, full_access: bool = False) -> dict:
+    """Create a share link. full_access=True allows editing."""
+    return await api_post(f"/api/trips/{trip_id}/share", {"is_full_access": full_access})
+
+@mcp.tool()
+async def invite_member(trip_id: int, username: str) -> dict:
+    """Invite a user to collaborate."""
+    return await api_post(f"/api/trips/{trip_id}/members", {"user": username})
+
+if __name__ == "__main__":
+    mcp.run(transport="sse", host="0.0.0.0", port=3001)

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -34,7 +34,8 @@ async def delete_trip(trip_id: int) -> dict:
 
 @mcp.tool()
 async def link_places(trip_id: int, place_ids: list[int]) -> dict:
-    """Link places to a trip. Must be called before adding items with place references."""
+    """Replace the full set of places linked to a trip. Existing links not in place_ids are removed.
+    Must be called before adding items with place references."""
     return await api_put(f"/api/trips/{trip_id}", {"place_ids": place_ids})
 
 # ── Days ──
@@ -47,10 +48,9 @@ async def add_day(trip_id: int, label: str, date: str = "") -> dict:
     return await api_post(f"/api/trips/{trip_id}/days", data)
 
 @mcp.tool()
-async def update_day(trip_id: int, day_id: int, label: str = "", date: str = "") -> dict:
-    """Update a day."""
-    data = {}
-    if label: data["label"] = label
+async def update_day(trip_id: int, day_id: int, label: str, date: str = "") -> dict:
+    """Update a day. label is required (use get_trip to retrieve the current value if only updating the date)."""
+    data: dict = {"label": label}
     if date: data["dt"] = date
     return await api_put(f"/api/trips/{trip_id}/days/{day_id}", data)
 
@@ -70,11 +70,20 @@ async def add_item(trip_id: int, day_id: int, text: str, time: str = "09:00",
     return await api_post(f"/api/trips/{trip_id}/days/{day_id}/items", data)
 
 @mcp.tool()
-async def update_item(trip_id: int, day_id: int, item_id: int, text: str = "", time: str = "") -> dict:
-    """Update an item."""
-    data = {}
+async def update_item(trip_id: int, day_id: int, item_id: int, text: str = "", time: str = "",
+                      price: float | None = None, status: str = "",
+                      place_id: int | None = None, remove_place: bool = False) -> dict:
+    """Update an item. Always pass place_id to preserve the place reference (use get_trip to retrieve it).
+    Set remove_place=True to detach the place. Status: pending/booked/constraint/optional."""
+    data: dict = {}
     if text: data["text"] = text
     if time: data["time"] = time
+    if price is not None: data["price"] = price
+    if status: data["status"] = status
+    if remove_place:
+        data["place"] = None
+    elif place_id is not None:
+        data["place"] = place_id
     return await api_put(f"/api/trips/{trip_id}/days/{day_id}/items/{item_id}", data)
 
 @mcp.tool()
@@ -150,4 +159,4 @@ async def invite_member(trip_id: int, username: str) -> dict:
     return await api_post(f"/api/trips/{trip_id}/members", {"user": username})
 
 if __name__ == "__main__":
-    mcp.run(transport="sse", host="0.0.0.0", port=3001)
+    mcp.run(transport="http", host="0.0.0.0", port=3001)


### PR DESCRIPTION
MCP (Model Context Protocol) server that exposes TRIP's API as AI tools. Lets Claude, OpenClaw, and other AI assistants create and manage trips via natural language.

## 22 Tools
- **Trips**: create, list, get, update, delete, link_places
- **Days**: add, update, delete
- **Items**: add, update, delete
- **Places**: create, list, update, delete
- **Categories**: list, create
- **Packing**: add_packing_item
- **Checklist**: add_checklist_item
- **Sharing**: share_trip, invite_member

## Stack
- FastMCP + SSE transport
- JWT auth with token caching (httpx)
- Docker deployment

## Usage
```bash
# Environment
TRIP_API_URL=http://localhost:8080
TRIP_USERNAME=your_user
TRIP_PASSWORD=your_pass

# Run
docker compose up -d
```

Claude Code config:
```json
{"mcpServers": {"trip": {"type": "sse", "url": "http://localhost:3001/sse"}}}
```

Then ask Claude: "Create a 3-day trip to Porto" and it calls the tools automatically.

## Files
- `mcp-server/server.py` — 22 tool definitions
- `mcp-server/auth.py` — JWT login + token cache
- `mcp-server/Dockerfile` — containerized
- `mcp-server/README.md` — setup guide

No changes to existing TRIP code. Only adds the `mcp-server/` directory.