### PR TITLE
force pydantic to not allow adding new fields on packing list element | better fallback on UI while showing packing list

### DIFF
--- a/backend/trip/models/models.py
+++ b/backend/trip/models/models.py
@@ -893,10 +893,17 @@ class TripPackingListItem(TripPackingListItemBase, table=True):
 
 
 class TripPackingListItemCreate(TripPackingListItemBase):
+    text: str = Field(min_length=1)
+    category: PackingListCategoryEnum
     packed: bool = False
 
+    class Config:
+        extra = "forbid"
 
-class TripPackingListItemUpdate(TripPackingListItemBase): ...
+
+class TripPackingListItemUpdate(TripPackingListItemBase):
+    class Config:
+        extra = "forbid"
 
 
 class TripPackingListItemRead(TripPackingListItemBase):

--- a/src/src/app/components/trip/trip.component.ts
+++ b/src/src/app/components/trip/trip.component.ts
@@ -337,7 +337,7 @@ export class TripComponent implements AfterViewInit, OnDestroy {
   dispPackingList = computed(() => {
     const list = this.packingList();
     const sorted = [...list].sort((a, b) =>
-      a.packed !== b.packed ? (a.packed ? 1 : -1) : a.text.localeCompare(b.text),
+      a.packed !== b.packed ? (a.packed ? 1 : -1) : (a.text || '').localeCompare(b.text || ''),
     );
 
     return sorted.reduce<Record<string, PackingItem[]>>((acc, item) => {

--- a/src/src/app/types/settings.ts
+++ b/src/src/app/types/settings.ts
@@ -18,6 +18,7 @@ export interface Settings {
   map_provider?: string;
   duplicate_dist?: number;
   is_admin?: boolean;
+  language?: string;
 }
 
 export interface ImportResponse {


### PR DESCRIPTION
Related to issue #247 

The problem was, due to lack of validation on the API, when adding an element to the packing list, it dindt block the request if it had extra fields neither if the main field - **text** - was not provided.

This made the UI break when trying to load the packing list.