### PR TITLE
fix: item creation was using wrong object

### DIFF
--- a/backend/trip/routers/trips.py
+++ b/backend/trip/routers/trips.py
@@ -384,7 +384,7 @@ def create_tripitem(
         day_id=day_id,
         price=item.price,
         status=item.status,
-        links=items.links
+        links=item.links
     )
 
     filename = None


### PR DESCRIPTION
This fixes https://github.com/itskovacs/trip/issues/265

Probably better you redo the change, because both vim, zed and github editor insists on adding the final newline and it's pretty late so I gave up. But this fixes the issue.